### PR TITLE
Feature automatically run specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,9 @@
 source 'https://rubygems.org'
 
 gem 'gosu'
-gem 'rspec'
+
+group :development do
+  gem 'rspec'
+  gem 'guard-rspec', require: false
+  gem 'pry'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,41 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    coderay (1.1.1)
     diff-lcs (1.2.5)
+    ffi (1.9.10)
+    formatador (0.2.5)
     gosu (0.9.2)
+    guard (2.13.0)
+      formatador (>= 0.2.4)
+      listen (>= 2.7, <= 4.0)
+      lumberjack (~> 1.0)
+      nenv (~> 0.1)
+      notiffany (~> 0.0)
+      pry (>= 0.9.12)
+      shellany (~> 0.0)
+      thor (>= 0.18.1)
+    guard-compat (1.2.1)
+    guard-rspec (4.6.4)
+      guard (~> 2.1)
+      guard-compat (~> 1.1)
+      rspec (>= 2.99.0, < 4.0)
+    listen (3.0.6)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9.7)
+    lumberjack (1.0.10)
+    method_source (0.8.2)
+    nenv (0.3.0)
+    notiffany (0.0.8)
+      nenv (~> 0.1)
+      shellany (~> 0.0)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    rb-fsevent (0.9.7)
+    rb-inotify (0.9.7)
+      ffi (>= 0.5.0)
     rspec (3.3.0)
       rspec-core (~> 3.3.0)
       rspec-expectations (~> 3.3.0)
@@ -16,12 +49,17 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
+    shellany (0.0.1)
+    slop (3.6.0)
+    thor (0.19.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   gosu
+  guard-rspec
+  pry
   rspec
 
 BUNDLED WITH

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,31 @@
+# A sample Guardfile
+# More info at https://github.com/guard/guard#readme
+
+## Uncomment and set this to only include directories you want to watch
+# directories %w(app lib config test spec features) \
+#  .select{|d| Dir.exists?(d) ? d : UI.warning("Directory #{d} does not exist")}
+
+## Note: if you are using the `directories` clause above and you are not
+## watching the project directory ('.'), then you will want to move
+## the Guardfile to a watched dir and symlink it back, e.g.
+#
+#  $ mkdir config
+#  $ mv Guardfile config/
+#  $ ln -s config/Guardfile .
+#
+# and, you'll have to watch "config/Guardfile" instead of "Guardfile"
+
+# Note: The cmd option is now required due to the increasing number of ways
+#       rspec may be run, below are examples of the most common uses.
+#  * bundler: 'bundle exec rspec'
+#  * bundler binstubs: 'bin/rspec'
+#  * spring: 'bin/rspec' (This will use spring if running and you have
+#                          installed the spring binstubs per the docs)
+#  * zeus: 'zeus rspec' (requires the server to be started separately)
+#  * 'just' rspec: 'rspec'
+
+guard :rspec, cmd: 'rspec' do
+  watch(%r{^spec/.+_spec\.rb$})
+  watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
+  watch('spec/spec_helper.rb')  { "spec" }
+end

--- a/spec/lib/board_item_spec.rb
+++ b/spec/lib/board_item_spec.rb
@@ -16,7 +16,7 @@ describe BoardItem do
   describe ".draw" do
     it "calls draw on the sprites" do
       tile = double("Tile")
-      board_item.stub(sprite: tile)
+      allow(board_item).to receive(:sprite).and_return(tile)
       expect(tile).to receive(:draw)
       board_item.draw
     end

--- a/spec/lib/board_map_spec.rb
+++ b/spec/lib/board_map_spec.rb
@@ -16,7 +16,7 @@ describe BoardMap do
   describe ".draw" do
     it "calls draw on the sprites" do
       tile = double("Tile")
-      board_map.stub(sprite: tile)
+      allow(board_map).to receive(:sprite).and_return(tile)
       expect(tile).to receive(:draw)
       board_map.draw
     end

--- a/spec/lib/board_position_spec.rb
+++ b/spec/lib/board_position_spec.rb
@@ -16,7 +16,7 @@ describe BoardPosition do
     context "is open" do
       it "calls draw on the BoardSprite" do
         draw_count = 0
-        board_position.stub(:open?) { true }
+        allow(board_position).to receive(:open?).and_return(true)
         allow_any_instance_of(BoardSprite).to receive(:draw) { draw_count += 1 }
         board_position.draw
         expect(draw_count).to eq 2
@@ -26,7 +26,7 @@ describe BoardPosition do
     context "is not open" do
       it "calls draw on the BoardSprite" do
         draw_count = 0
-        board_position.stub(:open?) { false }
+        allow(board_position).to receive(:open?).and_return(false)
         allow_any_instance_of(BoardSprite).to receive(:draw) { draw_count += 1 }
         board_position.draw
         expect(draw_count).to eq 1

--- a/spec/lib/board_sprite_spec.rb
+++ b/spec/lib/board_sprite_spec.rb
@@ -16,7 +16,7 @@ describe BoardSprite do
   describe ".draw" do
     it "calls draw on the sprites" do
       tile = double("Tile")
-      board_sprite.stub(sprite: tile)
+      allow(board_sprite).to receive(:sprite).and_return(tile)
       expect(tile).to receive(:draw)
       board_sprite.draw
     end

--- a/spec/lib/heart_meter_spec.rb
+++ b/spec/lib/heart_meter_spec.rb
@@ -6,8 +6,8 @@ describe HeartMeter do
 
   describe ".update" do
     it "updates the heart meter with new values from the player" do
-      player.stub(max_health: player.max_health + 1)
-      player.stub(health:     player.health     + 1)
+      allow(player).to receive(:max_health).and_return(player.max_health + 1)
+      allow(player).to receive(:health    ).and_return(player.health     + 1)
       heart_meter.update
       expect(heart_meter.send(:max_health)).to eq 6
       expect(heart_meter.send(:health)    ).to eq 4
@@ -17,7 +17,7 @@ describe HeartMeter do
   describe ".draw" do
     it "renders the hearts in the meter" do
       heart = double("Heart")
-      heart_meter.stub(hearts: [heart])
+      allow(heart_meter).to receive(:hearts).and_return([heart])
       expect(heart).to receive(:draw)
       heart_meter.draw
     end

--- a/spec/lib/heart_spec.rb
+++ b/spec/lib/heart_spec.rb
@@ -16,7 +16,7 @@ describe Heart do
   describe ".draw" do
     it "calls draw on the sprites" do
       tile = double("Tile")
-      heart.stub(sprite: tile)
+      allow(heart).to receive(:sprite).and_return(tile)
       expect(tile).to receive(:draw)
       heart.draw
     end

--- a/spec/lib/scene_spec.rb
+++ b/spec/lib/scene_spec.rb
@@ -34,7 +34,7 @@ describe Scene do
   describe ".draw" do
     it "draw each sprite" do
       sprite = double("Player")
-      scene.stub(sprites: [sprite])
+      allow(scene).to receive(:sprites).and_return([sprite])
       expect(scene.sprites.first).to receive(:draw)
       scene.draw
     end


### PR DESCRIPTION
Use Guard, Guard-RSpec, and Pry in development. This allows us to automatically run specs when code or specs change. Also, with Pry added we can now more easily debug problems.
